### PR TITLE
Revert package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,8 @@ updates:
   reviewers:
     - "martincostello"
   open-pull-requests-limit: 99
+  ignore:
+    - dependency-name: Microsoft.Extensions.Http.Resilience
+    - dependency-name: Microsoft.Extensions.Logging.Console
+    - dependency-name: System.Formats.Asn1
+    - dependency-name: System.Text.Json

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="JustEat.HttpClientInterception" Version="5.0.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="NSubstitute" Version="5.1.0" />
     <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="Spectre.Console.Testing" Version="0.49.1" />
     <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
- Revert package updates for `net8.0`.
- Configure dependabot to ignore those dependencies.
