### PR TITLE
Use lint-actions-powershell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          filter: 'tree:0'
+          show-progress: false
           token: ${{ secrets.COSTELLOBOT_TOKEN }}
 
       - name: Bump version
@@ -94,7 +96,7 @@ jobs:
           git rev-parse --verify --quiet "remotes/origin/${branchName}" | Out-Null
 
           if ($LASTEXITCODE -eq 0) {
-            Write-Host "Branch ${branchName} already exists."
+            Write-Output "Branch ${branchName} already exists."
             exit 0
           }
 

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@dd746615b3b9d728a6a37ca2045b68ca76d4841a # v3.28.8

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          filter: 'tree:0'
+          show-progress: false
 
       - name: Review dependencies
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ permissions:
 
 env:
   FORCE_COLOR: 3
+  POWERSHELL_YAML_VERSION: '0.4.12'
+  PSSCRIPTANALYZER_VERSION: '1.23.0'
   TERM: xterm
 
 jobs:
@@ -29,6 +31,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Add actionlint problem matcher
       run: echo "::add-matcher::.github/actionlint-matcher.json"
@@ -44,6 +49,13 @@ jobs:
         config: '.markdownlint.json'
         globs: |
           **/*.md
+
+    - name: Lint PowerShell in workflows
+      uses: martincostello/lint-actions-powershell@5942e3350ee5bd8f8933cec4e1185d13f0ea688f # v1.0.0
+      with:
+        powershell-yaml-version: ${{ env.POWERSHELL_YAML_VERSION }}
+        psscriptanalyzer-version: ${{ env.PSSCRIPTANALYZER_VERSION }}
+        treat-warnings-as-errors: true
 
     - name: Lint PowerShell
       shell: pwsh

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          filter: 'tree:0'
           persist-credentials: false
+          show-progress: false
 
       - name: Run analysis
         uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          filter: 'tree:0'
+          show-progress: false
           token: ${{ secrets.COSTELLOBOT_TOKEN }}
 
       - name: Get version


### PR DESCRIPTION
- Use martincostello/lint-actions-powershell to lint PowerShell code embedded in GitHub Actions workflow files.
- Add filter and hide progress when checking out code.
