### PR TITLE
Add release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot[bot]
+      - costellobot
+      - costellobot[bot]
+      - github-actions[bot]
+      - renovate[bot]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Setup .NET SDK

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Review dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,6 +35,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Add actionlint problem matcher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,30 +50,17 @@ jobs:
             const draft = process.env.DRAFT === 'true';
             const version = process.env.VERSION;
             const tag_name = `v${version}`;
+            const target_commitish = process.env.DEFAULT_BRANCH;
             const name = tag_name;
-
-            const { data: notes } = await github.rest.repos.generateReleaseNotes({
-              owner,
-              repo,
-              tag_name,
-              target_commitish: process.env.DEFAULT_BRANCH,
-            });
-
-            const body = notes.body
-              .split('\n')
-              .filter((line) => !line.includes(' @costellobot '))
-              .filter((line) => !line.includes(' @dependabot '))
-              .filter((line) => !line.includes(' @github-actions '))
-              .filter((line) => !line.includes(' @renovate[bot] '))
-              .join('\n');
 
             const { data: release } = await github.rest.repos.createRelease({
               owner,
               repo,
               tag_name,
+              target_commitish,
               name,
-              body,
               draft,
+              generate_release_notes: true,
             });
 
             core.notice(`Created release ${release.name}: ${release.html_url}`);


### PR DESCRIPTION
Add a configuration file for generating GitHub release notes.

See [Configuring automatically generated release notes](https://docs.github.com/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes).
