### PR TITLE
Use NuGet Trusted Publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,6 +199,9 @@ jobs:
       name: NuGet.org
       url: https://www.nuget.org/packages/MartinCostello.WaitForNuGetPackage
 
+    permissions:
+      id-token: write
+
     steps:
 
     - name: Download packages
@@ -211,10 +214,16 @@ jobs:
       with:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
+    - name: NuGet log in
+      uses: NuGet/login@d883674c922ba7e5cc0370927b10a33b67d54677 # v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Push NuGet packages to NuGet.org
       shell: bash
       env:
-        API_KEY: ${{ secrets.NUGET_TOKEN }}
+        API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         PACKAGE_VERSION: ${{ needs.build.outputs.package-version }}
         SOURCE: https://api.nuget.org/v3/index.json
       run: dotnet nuget push "*.nupkg" --api-key "${API_KEY}" --skip-duplicate --source "${SOURCE}" && echo "::notice title=nuget.org::Published version ${PACKAGE_VERSION} to NuGet.org."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,7 +215,7 @@ jobs:
         dotnet-version: ${{ needs.build.outputs.dotnet-sdk-version }}
 
     - name: NuGet log in
-      uses: NuGet/login@d883674c922ba7e5cc0370927b10a33b67d54677 # v1
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
       id: nuget-login
       with:
         user: ${{ secrets.NUGET_USER }}


### PR DESCRIPTION
Switch to using GitHub OIDC for pushing packages to NuGet.org with Trusted Publishing.

> Depends on Trusted Publishing rolling out to my NuGet account. ⏳
