### PR TITLE
Remove workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,6 @@
 <Project>
   <PropertyGroup>
     <AssemblyIsCLSCompliant>false</AssemblyIsCLSCompliant>
-    <!-- HACK Workaround for https://github.com/dotnet/sdk/issues/17454 -->
-    <BuildInParallel Condition="$([System.OperatingSystem]::IsWindows())">false</BuildInParallel>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)WaitForNuGetPackage.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>


### PR DESCRIPTION
Remove workaround as it should be resolved in the latest .NET 9 and 10 SDKs.
