### PR TITLE
Add GitHub step summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,18 +101,19 @@ ARGUMENTS:
     [package-id]    The package ID(s), including an optional version, to wait for new versions to be published
 
 OPTIONS:
-                           DEFAULT
-    -h, --help                         Prints help information
-    -v, --version                      Prints version information
-    -q, --no-logo                      Suppresses the logo
-    -f, --file                         The NuGet package file(s) to wait for to be published
-    -d, --directory                    The directories to recursively search for NuGet package files to wait for to be
-                                       published
-    -i, --service-index                The NuGet service index URL to use
-    -s, --since            00:05:00    The period of time before now to include when searching for the published
-                                       package(s)
-    -t, --timeout                      The period of time to wait for the package(s) to be published
-        --verbose                      Enables verbose logging
+                               DEFAULT
+    -h, --help                             Prints help information
+    -v, --version                          Prints version information
+    -q, --no-logo                          Suppresses the logo
+    -f, --file                             The NuGet package file(s) to wait for to be published
+    -d, --directory                        The directories to recursively search for NuGet package files to wait for to
+                                           be published
+    -i, --service-index                    The NuGet service index URL to use
+    -s, --since                00:05:00    The period of time before now to include when searching for the published
+                                           package(s)
+    -t, --timeout                          The period of time to wait for the package(s) to be published
+        --verbose                          Enables verbose logging
+        --no-github-summary                Suppresses the GitHub summary when running in GitHub Actions
 ```
 
 ## Building and Testing

--- a/src/WaitForNuGetPackage/WaitCommand.cs
+++ b/src/WaitForNuGetPackage/WaitCommand.cs
@@ -81,6 +81,30 @@ internal sealed class WaitCommand(
             var plural = count is 1 ? string.Empty : "s";
 
             console.MarkupLineInterpolated($"[{color}]{count} package{plural} found published after {elapsed}.[/]");
+
+            if (result == 0 &&
+                settings.NoGitHubSummary is not true &&
+                Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is "true" &&
+                Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY") is { Length: > 0 } stepSummaryPath)
+            {
+                var builder = new StringBuilder()
+                    .AppendLine()
+                    .AppendLine($"## WaitForNuGetPackage Summary")
+                    .AppendLine();
+
+                builder.AppendLine($"| **Package ID** | **Version** |")
+                       .AppendLine($"|:---------------|:------------|");
+
+                foreach ((var package, var version) in packages.ObservedPackages.OrderBy((p) => p.Id, comparer).ThenBy((p) => p.Version, comparer))
+                {
+                    builder.AppendLine(CultureInfo.InvariantCulture, $"| [{package}](https://www.nuget.org/packages/{package}/{version}) | `{version}` |");
+                }
+
+                builder.AppendLine()
+                       .AppendLine();
+
+                await File.AppendAllTextAsync(stepSummaryPath, builder.ToString(), cancellationToken);
+            }
         }
         catch (OperationCanceledException)
         {

--- a/src/WaitForNuGetPackage/WaitCommand.cs
+++ b/src/WaitForNuGetPackage/WaitCommand.cs
@@ -89,7 +89,7 @@ internal sealed class WaitCommand(
             {
                 var builder = new StringBuilder()
                     .AppendLine()
-                    .AppendLine($"## WaitForNuGetPackage Summary")
+                    .AppendLine($"## WaitForNuGetPackage Summary :package:")
                     .AppendLine();
 
                 builder.AppendLine($"| **Package ID** | **Version** |")

--- a/src/WaitForNuGetPackage/WaitCommand.cs
+++ b/src/WaitForNuGetPackage/WaitCommand.cs
@@ -82,7 +82,7 @@ internal sealed class WaitCommand(
 
             console.MarkupLineInterpolated($"[{color}]{count} package{plural} found published after {elapsed}.[/]");
 
-            if (result == 0 &&
+            if (packages.ObservedPackages.Count > 0 &&
                 settings.NoGitHubSummary is not true &&
                 Environment.GetEnvironmentVariable("GITHUB_ACTIONS") is "true" &&
                 Environment.GetEnvironmentVariable("GITHUB_STEP_SUMMARY") is { Length: > 0 } stepSummaryPath)

--- a/src/WaitForNuGetPackage/WaitCommandSettings.cs
+++ b/src/WaitForNuGetPackage/WaitCommandSettings.cs
@@ -70,6 +70,13 @@ internal sealed class WaitCommandSettings : CommandSettings
     [Description("Enables verbose logging.")]
     public bool? Verbose { get; set; }
 
+    /// <summary>
+    /// Gets or sets an optional value indicating whether to disable the GitHub summary.
+    /// </summary>
+    [CommandOption("--no-github-summary")]
+    [Description("Suppresses the GitHub summary when running in GitHub Actions.")]
+    public bool? NoGitHubSummary { get; set; }
+
     /// <inheritdoc/>
     public override ValidationResult Validate()
     {


### PR DESCRIPTION
Emit a GitHub step summary for published packages when running in GitHub Actions, which can be suppressed using `--no-github-summary`.
