### PR TITLE
Improve UX during discovery

### DIFF
--- a/src/WaitForNuGetPackage/PackageWaitContext.cs
+++ b/src/WaitForNuGetPackage/PackageWaitContext.cs
@@ -31,6 +31,8 @@ internal sealed class PackageWaitContext(IAnsiConsole console, WaitCommandSettin
 
         foreach (var fileName in _settings.Files)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             string path;
 
             try
@@ -76,6 +78,8 @@ internal sealed class PackageWaitContext(IAnsiConsole console, WaitCommandSettin
 
         foreach (var directory in _settings.Directories)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             string path = directory;
 
             try
@@ -84,10 +88,11 @@ internal sealed class PackageWaitContext(IAnsiConsole console, WaitCommandSettin
 
                 foreach (var file in Directory.EnumerateFiles(path, "*.nupkg", SearchOption.AllDirectories))
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     files.Add(file);
                 }
             }
-            catch (Exception ex)
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
                 _console.WriteAnsi((writer) =>
                 {

--- a/src/WaitForNuGetPackage/WaitCommand.cs
+++ b/src/WaitForNuGetPackage/WaitCommand.cs
@@ -26,7 +26,13 @@ internal sealed class WaitCommand(
             console.WriteLine();
         }
 
-        if (!await packages.DiscoverPackagesAsync(cancellationToken))
+        var foundPackages = await console
+            .Status()
+            .Spinner(Spinner.Known.Dots)
+            .SpinnerStyle(Style.Parse("purple"))
+            .StartAsync("Discovering NuGet packages...", async (_) => await packages.DiscoverPackagesAsync(cancellationToken));
+
+        if (!foundPackages)
         {
             return -1;
         }


### PR DESCRIPTION
- Add a spinner during package discovery.
- Make package enumeration responsive to cancellation.
