### PR TITLE
Set SOURCE_DATE_EPOCH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,12 @@ jobs:
         persist-credentials: false
         show-progress: false
 
+    - name: Get Git commit timestamp
+      id: get-commit-timestamp
+      shell: pwsh
+      run: |
+        "epoch=$(git log -1 --pretty=%ct)" >> ${env:GITHUB_OUTPUT}
+
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       id: setup-dotnet
@@ -66,6 +72,8 @@ jobs:
       id: build
       shell: pwsh
       run: ./build.ps1
+      env:
+        SOURCE_DATE_EPOCH: ${{ steps.get-commit-timestamp.outputs.epoch }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0


### PR DESCRIPTION
Set the `SOURCE_DATE_EPOCH` to the date of the checked-out Git commit to use for [NuGet's `DeterministicTimestamp` in .NET 11](https://github.com/dotnet/core/blob/main/release-notes/11.0/preview/preview5/nuget.md#deterministic-pack-support-is-restored).
